### PR TITLE
Add basic clothing card and container templates

### DIFF
--- a/closet/src/components/Card.js
+++ b/closet/src/components/Card.js
@@ -1,9 +1,0 @@
-const Card = () => {
-    return (
-        <div>
-            Card
-        </div>
-    );
-};
-
-export default Card;

--- a/closet/src/components/ClothingCard.js
+++ b/closet/src/components/ClothingCard.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+class ClothingCard extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+
+      /*
+        Grabs "props" data, data that was sent from the ClothingCardContainer class
+
+        Refer to: ClothingCardContainer.js
+      */
+      imgUrl: props.imgUrl,
+      name: props.name || '',
+      size: props.size || '',
+      category: props.category || ''
+    }
+  }
+
+  render() {
+    return (
+      <Card style={{ width: 250, margin: 10 }}>
+        <CardActionArea>
+          <CardMedia style={{ height: 250, width: 250 }} image={this.state.imgUrl} title={this.state.name}/>
+          <CardContent>
+            <Typography gutterBottom variant="h6" component="h2">
+              {this.state.name}
+            </Typography>
+          </CardContent>
+        </CardActionArea>
+        <CardActions>
+          <Button size="small" color="primary">
+            Share
+          </Button>
+          <Button size="small" color="primary">
+            Learn More
+          </Button>
+        </CardActions>
+      </Card>
+    );
+  }
+}
+
+export default ClothingCard;

--- a/closet/src/components/ClothingCardContainer.js
+++ b/closet/src/components/ClothingCardContainer.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Grid } from '@material-ui/core';
+import ClothingCard from './ClothingCard';
+
+class ClothingCardContainer extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      /*
+        Hard initialized clothing array
+        Future usage: Use a GET request to obtain listing of clothings from a database
+
+        This will store basic data for display usage only and is sent to the render() function
+      */
+      clothing: [
+        {
+          imgUrl: 'https://picsum.photos/250',
+          name: "Awesome T-Shirt",
+          size: 'XL',
+          category: 'Category1'
+        },
+        {
+          imgUrl: 'https://picsum.photos/250',
+          name: "Poopy Jeans",
+          size: 'SM',
+          category: 'Category2'
+        },
+        {
+          imgUrl: 'https://picsum.photos/250',
+          name: "THICC Sweater",
+          size: 'XXXXXXXL',
+          category: 'Category3'
+        }
+      ]
+    }
+  }
+
+  render() {
+    return (
+      /*
+        Generates a grid and iterates through the clothing array and passes in 
+        related data and generates a "ClothingCard" component
+
+        Refer to: https://material-ui.com/components/grid/
+      */
+      <Grid container style={{ flexGrow: 1, marginTop: 10, marginBottom: 10 }}>
+        <Grid item xs={12}>
+          <Grid container justifyContent="center">
+            {this.state.clothing.map((value) => (
+              <Grid key={value} item>
+                <ClothingCard
+                  name={value.name}
+                  imgUrl={value.imgUrl}
+                />
+              </Grid>
+            ))}
+          </Grid>
+        </Grid>
+      </Grid>
+    );
+  }
+}
+
+export default ClothingCardContainer;

--- a/closet/src/components/Details.js
+++ b/closet/src/components/Details.js
@@ -1,9 +1,9 @@
+import ClothingCardContainer from './ClothingCardContainer';
+
 const Details = () => {
-    return (
-        <div>
-            Details
-        </div>
-    );
+  return (
+    <ClothingCardContainer />
+  );
 };
 
 export default Details;


### PR DESCRIPTION
### Added

- New "ClothingCard" class that will display basic clothing data retrieved from container class.
- New "ClothingCardContainer" class that will display an array of "ClothingCard".

### Fixed

- Removed "Card" class, using "ClothingCard", as "Card" class would conflict with material/ui/card when importing and exporting